### PR TITLE
Preparation for pypi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,108 @@
+# IDE user files
+.idea/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.md
+include LICENSE.md

--- a/README.md
+++ b/README.md
@@ -12,41 +12,47 @@ Copyright 2013 - [Helder Correia](http://heldercorreia.com) (GPL2)
 --------------------------------------------
 
 Example – this source:
+```markdown
+Bla bla bla
 
-    Bla bla bla
+![this is the caption](http://lorempixel.com/400/200/)
 
-    ![this is the caption](http://lorempixel.com/400/200/)
-
-    Next paragraph starts here
+Next paragraph starts here
+```
+    
 
 would generate this:
 
-    <p> Bla bla bla</p>
-    
-    <figure>
-        <img src="http://lorempixel.com/400/200/">
-        <figcaption>this is the caption</figcaption>
-    </figure>
-   
-    <p>Next paragraph starts here</p>
+```html
+<p> Bla bla bla</p>
 
+<figure>
+    <img src="http://lorempixel.com/400/200/">
+    <figcaption>this is the caption</figcaption>
+</figure>
+
+<p>Next paragraph starts here</p>
+```
 
 
 It can also handle images that use references and/or titles :
 
-    Some really good writing.
+```markdown
+Some really good writing.
 
-    ![Description of something cool.][ref1]
+![Description of something cool.][ref1]
 
-    More great writing.
+More great writing.
 
-    [ref1]: http://lorempixel.com/400/200/ "A title for the cool image."
+[ref1]: http://lorempixel.com/400/200/ "A title for the cool image."
+```
 
 would generate this:
+```html
+<p>Some really good writing.</p>
 
-    <p>Some really good writing.</p>
+<figure><img alt="Description of something cool." src="http://lorempixel.com/400/200/" title="A title for the cool image."><figcaption>Description of something cool.</figcaption>
+</figure>
 
-    <figure><img alt="Description of something cool." src="http://lorempixel.com/400/200/" title="A title for the cool image."><figcaption>Description of something cool.</figcaption>
-    </figure>
-
-    <p>More great writing.</p>
+<p>More great writing.</p>
+```

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,26 @@
 
 from setuptools import setup
 
+with open('README.md') as f:
+    readme = f.read()
+
 setup(
     name='figureAltCaption',
+    version='1.0.0',
     description='Extension for Python-Markdown to parse images with captions.',
+    long_description=readme,
+    long_description_content_type="text/markdown",
     url='https://github.com/jdittrich/figureAltCaption',
     py_modules=['figureAltCaption'],
-    install_requires=['Markdown>=2.0',],
+    install_requires=['Markdown>=2.0', ],
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Environment :: Plugins',
+        'Intended Audience :: Developers',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Topic :: Documentation',
+        'Topic :: Text Processing :: Markup',
+        'Topic :: Utilities'
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     long_description_content_type="text/markdown",
     url='https://github.com/jdittrich/figureAltCaption',
     py_modules=['figureAltCaption'],
-    install_requires=['Markdown>=2.0', ],
+    install_requires=['Markdown>=2.0,<3.0', ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Plugins',

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Environment :: Plugins',
         'Intended Audience :: Developers',
+        'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Topic :: Documentation',


### PR DESCRIPTION
## Changes
- Added readme as long_description
- Added version 1.0.0
- Added some classifiers
- Added python .gitignore file
- See #5

## Missing
- Author (or maintainer) name and email (can be a username)
- Python classifiers for supported python versions ([see list](https://pypi.org/pypi?%3Aaction=list_classifiers))
-  ~~License (recommended)~~
- Changelog

I also added an upper limit for `Markdown` requirement since it's not working on 3.0. When support is added, the upper limit should be removed.
