### PR TITLE
Fix for using with Markdown 3.0.1

### DIFF
--- a/figureAltCaption.py
+++ b/figureAltCaption.py
@@ -30,7 +30,7 @@ would generate a figure like this:
 
 from __future__ import unicode_literals
 from markdown import Extension
-from markdown.inlinepatterns import IMAGE_LINK_RE, IMAGE_REFERENCE_RE, NOBRACKET, BRK
+from markdown.inlinepatterns import IMAGE_LINK_RE, IMAGE_REFERENCE_RE
 from markdown.blockprocessors import BlockProcessor
 from markdown.util import etree
 import re #regex
@@ -79,5 +79,7 @@ class FigureCaptionExtension(Extension):
                                       FigureCaptionProcessor(md.parser),
                                       '<ulist')
 
-def makeExtension(configs={}):
-    return FigureCaptionExtension(configs=configs)
+# def makeExtension(configs={}):
+#     return FigureCaptionExtension(configs=configs)
+def makeExtension(**kwargs):  # pragma: no cover
+    return FigureCaptionExtension(**kwargs)

--- a/figureAltCaption.py
+++ b/figureAltCaption.py
@@ -38,7 +38,7 @@ import re #regex
 import logging
 logger = logging.getLogger('MARKDOWN')
 
-FIGURES = [u'^\s*'+IMAGE_LINK_RE+u'\s*$', u'^\s*'+IMAGE_LINK_RE+u'\{.*?\}'+u'\s*$', u'^\s*'+IMAGE_REFERENCE_RE+u'\s*$'] #is: linestart, any whitespace (even none), image, any whitespace (even none), line ends.
+FIGURES = [u'^\s*'+IMAGE_LINK_RE, u'^\s*'+IMAGE_REFERENCE_RE] #is: linestart, any whitespace (even none), image, any whitespace (even none), line ends.
 CAPTION = r'\[(?P<caption>[^\]]*)\]' # Get the contents within the first set of brackets
 ATTR = r'\{(?P<attributes>[^\}]*)\}'
 
@@ -53,9 +53,10 @@ class FigureCaptionProcessor(BlockProcessor):
         isImage = bool(self.FIGURES_RE.search(block))
         isOnlyOneLine = (len(block.splitlines())== 1)
         isInFigure = (parent.tag == 'figure')
-
+        
         # print(block, isImage, isOnlyOneLine, isInFigure, "T,T,F")
         if (isImage and isOnlyOneLine and not isInFigure):
+            print(block)
             return True
         else:
             return False

--- a/figureAltCaption.py
+++ b/figureAltCaption.py
@@ -79,7 +79,5 @@ class FigureCaptionExtension(Extension):
                                       FigureCaptionProcessor(md.parser),
                                       '<ulist')
 
-# def makeExtension(configs={}):
-#     return FigureCaptionExtension(configs=configs)
 def makeExtension(**kwargs):  # pragma: no cover
     return FigureCaptionExtension(**kwargs)


### PR DESCRIPTION
The `NOBRACKET` and `BRK` are no longer available in `markdown.inlinepatterns`. As they are not used in the code they can be removed.

Also the `makeExtension` call has been slightly changed.